### PR TITLE
Skip IntegrityError

### DIFF
--- a/soil/__init__.py
+++ b/soil/__init__.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from django.db import IntegrityError
 from django.core import cache
 from django.core.servers.basehttp import FileWrapper
 from django.core.urlresolvers import reverse
@@ -141,6 +142,9 @@ class DownloadBase(object):
             if task:
                 task.update_state(state='PROGRESS', meta={'current': current, 'total': total})
         except (TypeError, NotImplementedError):
+            pass
+        except IntegrityError:
+            # Not called in task context just pass
             pass
     
     @classmethod


### PR DESCRIPTION
This allows for `set_progress` to be called and not have an error be
thrown if it is in the context of a task.

A little sketchy to completely pass over integrity errors, but django doesn't let me access the column that has the error (unless I do string searching). The other option is to make task_id not required which seems suboptimal.

@czue 